### PR TITLE
Add support for handling QFace Enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ QtAidl module enables easy transition between both worlds:
 
 Currently only a subset of QFace IDL is supported. Support for the following major elements of [QFace grammar](https://qface.readthedocs.io/en/latest/grammar.html) are not implemented yet:
 * [Nested Types](https://qface.readthedocs.io/en/latest/grammar.html#nested-types)
-* [Enum/Flag](https://qface.readthedocs.io/en/latest/grammar.html#enum-flag)
+* [Flag](https://qface.readthedocs.io/en/latest/grammar.html#enum-flag)
 * `extends` [keyword](https://qface.readthedocs.io/en/latest/grammar.html#interface)
 
 Regarding the conversion rules between QFace IDL and AIDL the QtAidl module takes the following convention:

--- a/src/tools/ifcodegen/CMakeLists.txt
+++ b/src/tools/ifcodegen/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_copy_or_install(
   templates/aidl/callback.cpp.j2
   templates/aidl/CMakeLists.txt.j2
   templates/aidl/callback.aidl.j2
+  templates/aidl/enum.aidl.j2
   templates/aidl/service.aidl.j2
   templates/aidl/plugin.cpp.j2
   templates/aidl/backend.h.j2

--- a/src/tools/ifcodegen/templates/aidl.yaml
+++ b/src/tools/ifcodegen/templates/aidl.yaml
@@ -16,3 +16,6 @@ aidl:
     struct:
         documents:
             - "aidl/{{interface.module | module_path}}/{{struct}}.aidl": "struct.aidl.j2"
+    enums:
+        documents::
+            - "aidl/{{enum.module | module_path}}/{{enum}}.aidl" : enum.aidl.j2

--- a/src/tools/ifcodegen/templates/aidl/CMakeLists.txt.j2
+++ b/src/tools/ifcodegen/templates/aidl/CMakeLists.txt.j2
@@ -35,12 +35,15 @@ ${CMAKE_CURRENT_LIST_DIR}/{{module.module_name|lower}}plugin.cpp
 
 set(AIDL_FILES 
 {% for module in system.modules %}
+    {% for struct in module.structs %}
+        ${CMAKE_CURRENT_LIST_DIR}/aidl/{{module | module_path}}/{{struct}}.aidl
+    {% endfor %}
+    {% for enum in module.enums %}
+        ${CMAKE_CURRENT_LIST_DIR}/aidl/{{module | module_path}}/{{enum}}.aidl
+    {% endfor %}
     {% for interface in module.interfaces %}
         ${CMAKE_CURRENT_LIST_DIR}/aidl/{{module | module_path}}/I{{interface}}Service.aidl
         ${CMAKE_CURRENT_LIST_DIR}/aidl/{{module | module_path}}/I{{interface}}Callback.aidl
-    {% endfor %}
-    {% for struct in module.structs %}
-        ${CMAKE_CURRENT_LIST_DIR}/aidl/{{module | module_path}}/{{struct}}.aidl
     {% endfor %}
 {% endfor %}
 )

--- a/src/tools/ifcodegen/templates/aidl/backend.cpp.j2
+++ b/src/tools/ifcodegen/templates/aidl/backend.cpp.j2
@@ -82,6 +82,10 @@ void {{class}}::setService(const std::shared_ptr<module_ns::IStopwatchController
         std::string src;
         m_Service->{{property}}(&src);
         return QString::fromStdString(src);
+{%   elif property.type.is_enum %}
+        ::{{module | module_ns("aidl") }}::{{property.type}} src;
+        m_Service->{{property}}(&src);
+        return static_cast<{{property|return_type}}>(src);
 {%   else %}
         {{property|return_type}} src;
         m_Service->{{property}}(&src);
@@ -107,6 +111,8 @@ void {{class}}::setService(const std::shared_ptr<module_ns::IStopwatchController
         m_Service->set{{property.name|upperfirst}}(st);
 {%     elif property.type.is_string %}
         m_Service->set{{property.name|upperfirst}}({{property}}.toStdString());
+{%     elif property.type.is_enum %}
+        m_Service->set{{property.name|upperfirst}}(static_cast<ns::{{property.type}}>({{property}}));
 {%     else %}
         m_Service->set{{property.name|upperfirst}}({{property}});
 {%     endif %}
@@ -151,6 +157,8 @@ void {{class}}::initialize()
 {%      set _ = function_parameters.append(parameter.name +".toStdString()") %}
 {%    elif parameter.type.is_struct %}
 {%        set _ = function_parameters.append(parameter.name +"Aidl") %}
+{%    elif parameter.type.is_enum %}
+{%        set _ = function_parameters.append("static_cast<ns::" + parameter.type.name + ">(" + parameter.name +")") %}
 {%    else %}
 {%       set _ = function_parameters.append(parameter.name) %}
 {%    endif %}
@@ -172,8 +180,10 @@ void {{class}}::initialize()
 {%  if not operation.type.is_void %}
 {%    if operation.type.is_struct %}
         ns::{{operation|return_type}} result;
-{%    elif operation.type.is_string%}
+{%    elif operation.type.is_string %}
         std::string result;
+{%    elif operation.type.is_enum %}
+        ns::{{operation.type}} result;
 {%    else %}
         {{operation|return_type}} result;
 {%    endif %}
@@ -186,7 +196,6 @@ void {{class}}::initialize()
 {%       endfor %}
 {%    endif %}
 {%  endfor %}
-
         auto status = m_Service->{{operation}}({{params}});
         if (status.isOk()) {
 {%  if not operation.type.is_void %}
@@ -195,8 +204,10 @@ void {{class}}::initialize()
 {%       for field in operation.type.reference.fields %}
            resultValue.{{field|setter_name}}(result.{{field}});
 {%       endfor %}           
-{%    elif operation.type.is_string%}
+{%    elif operation.type.is_string %}
             QString resultValue = QString::fromStdString(result);
+{%    elif operation.type.is_enum %}
+            {{operation|return_type}} resultValue = static_cast<{{operation|return_type}}>(result);
 {%    else %}
             {{operation|return_type}} resultValue = result;
 {%    endif%}

--- a/src/tools/ifcodegen/templates/aidl/callback.aidl.j2
+++ b/src/tools/ifcodegen/templates/aidl/callback.aidl.j2
@@ -4,9 +4,10 @@
 #}
 
 package {{interface.module.name}};
-
-{% for t in interface | structures %}
+{% for t in interface | gether_interface_types %}
+{%   if t.is_struct or t.is_enum %}
 import {{interface.module.name}}.{{t.name}};
+{%   endif %}
 {% endfor %}
 
 interface I{{interface}}Callback {

--- a/src/tools/ifcodegen/templates/aidl/callback.cpp.j2
+++ b/src/tools/ifcodegen/templates/aidl/callback.cpp.j2
@@ -25,6 +25,8 @@ QT_BEGIN_NAMESPACE
 ndk::ScopedAStatus {{class}}::{{property}}Changed(const ::{{ns}}::{{property|return_type}}& {{property}})
 {% elif property.type.is_string %}
 ndk::ScopedAStatus {{class}}::{{property}}Changed(const std::string& {{property}})
+{% elif property.type.is_enum %}
+ndk::ScopedAStatus {{class}}::{{property}}Changed(::{{ns}}::{{property.type}} {{property}})
 {% else %}
 ndk::ScopedAStatus {{class}}::{{property}}Changed({{property|return_type}} {{property}})
 {% endif %}
@@ -39,6 +41,8 @@ ndk::ScopedAStatus {{class}}::{{property}}Changed({{property|return_type}} {{pro
     QMetaObject::invokeMethod(&m_controller, "{{property}}Changed",  Qt::ConnectionType::QueuedConnection, Q_ARG({{property|return_type}}, st));
 {% elif property.type.is_string %}
     QMetaObject::invokeMethod(&m_controller, "{{property}}Changed",  Qt::ConnectionType::QueuedConnection, Q_ARG({{property|return_type}}, QString::fromStdString({{property}})));
+{% elif property.type.is_enum %}
+    QMetaObject::invokeMethod(&m_controller, "{{property}}Changed",  Qt::ConnectionType::QueuedConnection, Q_ARG({{property|return_type}}, static_cast<{{property|return_type}}>({{property}})));
 {% else %}
     QMetaObject::invokeMethod(&m_controller, "{{property}}Changed",  Qt::ConnectionType::QueuedConnection, Q_ARG({{property|return_type}}, {{property}}));
 {% endif %}
@@ -52,6 +56,8 @@ ndk::ScopedAStatus {{class}}::{{property}}Changed({{property|return_type}} {{pro
 {%   for parameter in signal.parameters %}
 {%     if parameter.type.is_struct %}
 {%       set _ = signal_parameters.append("const ::" + ns + "::" + parameter|return_type + " in_" + parameter.name) %}
+{%     elif parameter.type.is_enum %}
+{%        set _ = signal_parameters.append("::" + ns + "::" + parameter.type.name + " in_" + parameter.name) %}
 {%     elif parameter.type.is_string %}
 {%       set _ = signal_parameters.append("const std::string& in_" + parameter.name) %}
 {%     else %}
@@ -72,6 +78,8 @@ ndk::ScopedAStatus {{class}}::{{signal}}({{signal_parameters|join(", ")}})
 {%     set _ = signal_args.append("Q_ARG(" + parameter|return_type + ", " + parameter.name + ")") %}
 {%   elif parameter.type.is_string %}
 {%     set _ = signal_args.append("Q_ARG(" + parameter|return_type + ", QString::fromStdString(in_" + parameter.name + "))") %}
+{%   elif parameter.type.is_enum %}
+{%     set _ = signal_args.append("Q_ARG(" + parameter|return_type + ", static_cast<" + parameter|return_type +">(in_" + parameter.name + "))") %}
 {%   else %}
 {%     set _ = signal_args.append("Q_ARG(" + parameter|return_type + ", in_" + parameter.name + ")") %}
 {%   endif %}

--- a/src/tools/ifcodegen/templates/aidl/callback.h.j2
+++ b/src/tools/ifcodegen/templates/aidl/callback.h.j2
@@ -30,6 +30,8 @@ public:
 {% for property in interface.properties %}
 {% if property.type.is_struct %}
     ndk::ScopedAStatus {{property}}Changed(const ::{{ns}}::{{property|return_type}}& in_{{property}}) override;
+{% elif property.type.is_enum %}
+    ndk::ScopedAStatus {{property}}Changed(::{{ns}}::{{property.type}} in_{{property}}) override;
 {% elif property.type.is_string %}
 ndk::ScopedAStatus {{property}}Changed(const std::string& in_{{property}}) override;
 {% else %}
@@ -44,6 +46,8 @@ ndk::ScopedAStatus {{property}}Changed(const std::string& in_{{property}}) overr
 {%       set _ = signal_parameters.append("const ::" + ns + "::" + parameter|return_type + " in_" + parameter.name) %}
 {%     elif parameter.type.is_string %}
 {%       set _ = signal_parameters.append("const std::string& in_" + parameter.name) %}
+{%     elif parameter.type.is_enum %}
+{%       set _ = signal_parameters.append(" ::" + ns + "::" + parameter.type.name + " in_" + parameter.name) %}
 {%     else %}
 {%       set _ = signal_parameters.append(parameter|return_type + " in_" + parameter.name) %}
 {%     endif %}

--- a/src/tools/ifcodegen/templates/aidl/enum.aidl.j2
+++ b/src/tools/ifcodegen/templates/aidl/enum.aidl.j2
@@ -1,0 +1,12 @@
+{#
+# Copyright (C) 2022 SpyroSoft S.A.
+# SPDX-License-Identifier: MIT
+#}
+
+package {{enum.module.name}};
+
+enum {{enum}} {
+{% for member in enum.members %}
+    {{member.name}} = {{member.value}}{% if not loop.last %},{% endif +%}
+{% endfor %}
+}

--- a/src/tools/ifcodegen/templates/aidl/filters.py
+++ b/src/tools/ifcodegen/templates/aidl/filters.py
@@ -18,25 +18,21 @@ def aidl_type(symbol):
     else: 
         return symbol.type.name
 
-def append_unique_structure(list, type):
-    if type.is_struct and not any(type.name == t.name for t in list):
-        list.append(type)
-
-def structures(interface):
+def gether_interface_types(interface):
     types = []
     for o in interface.operations:
         for p in o.parameters:
-            append_unique_structure(types, p.type)
-        append_unique_structure(types, o.type)
+            types.append(p.type)
+        types.append(o.type)
 
     for s in interface.signals:
         for p in s.parameters:
-            append_unique_structure(types, p.type)
+            types.append(p.type)
 
     for p in interface.properties:
-        append_unique_structure(types, p.type)
+        types.append(p.type)
 
-    return types
+    return set(types)
 
 def module_path(module, joint = '/', prefix = ""):
     name = module.name
@@ -59,4 +55,4 @@ def module_ns(module, prefix = ""):
 filters['module_path'] = module_path
 filters['module_ns'] = module_ns
 filters['aidl_type'] = aidl_type
-filters['structures'] = structures
+filters['gether_interface_types'] = gether_interface_types

--- a/src/tools/ifcodegen/templates/aidl/service.aidl.j2
+++ b/src/tools/ifcodegen/templates/aidl/service.aidl.j2
@@ -6,8 +6,10 @@
 package {{interface.module.name}};
 
 import {{interface.module.name}}.I{{interface}}Callback;
-{% for t in interface | structures %}
+{% for t in interface | gether_interface_types %}
+{%   if t.is_struct or t.is_enum %}
 import {{interface.module.name}}.{{t.name}};
+{%   endif %}
 {% endfor %}
 
 interface I{{interface}}Service {


### PR DESCRIPTION
Starting the Android 11 support for enums was added to AIDL language (https://source.android.com/docs/core/architecture/aidl/aidl-language#enums)

As both QFace and Qt Interface Framework also support enums this commit adds 'enum' based types as the supported types to generator templates

Github: #5